### PR TITLE
Project folder structure vs dotnet-ef tooling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
-    <!--<BaseIntermediateOutputPath>$(RepoRootPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>-->
+    <BaseIntermediateOutputPath>$(RepoRootPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
     <LangVersion>10.0</LangVersion>


### PR DESCRIPTION
Ich hab das da ja rein beschrieben, weil ich mir was dabei gedacht habe. Wenn Du es rausnimmst, macht das den Gedanken hinter der Struktur des Repos/Projektverzeichnisses kaputt. Wenn das zu einem Problem führt, lass uns besser das Problem lösen, als die Ordnerstruktur so zu organisieren, wie es die Auskommentierung tut (Intermediate-Dateien bei Code, Build Dateien gesondert).

Grundsätzlich ist das Ändern des BaseIntermediateOutputPath durchaus Linux-kompatibel.